### PR TITLE
Apple Silicon: bundle FreeType/GnuTLS, default Wine sync off, live install progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ build/
 Prereqs/*.exe
 Prereqs/*.msi
 
+# x86_64 FreeType/GnuTLS dependency chain — fetched + rewritten by
+# Prereqs/fetch-wine-libs.py from Homebrew's GHCR bottles, bundled into the
+# Wine runtime's lib/external. ~8 MB of dylibs; fetched on demand, not committed.
+Prereqs/wine-libs/
+
 # --- Microsoft fonts (fetched, not redistributable) ---
 # MS Core Fonts For The Web come in via Resources/Fonts/fetch.sh.
 # msyh.ttc / simsun.ttc must be supplied by the user from a Windows

--- a/Prereqs/fetch-wine-libs.py
+++ b/Prereqs/fetch-wine-libs.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Stage the x86_64 FreeType/GnuTLS dependency chain for bundling in
+D4Mac.app's Wine runtime (Contents/SharedSupport/Wine/lib/external/).
+
+Why this exists
+---------------
+The bundled Wine is x86_64 (runs under Rosetta). At runtime it dlopen()s a
+handful of unix libraries by bare leaf name — `libfreetype.6.dylib` (font
+rendering, used by win32u) and `libgnutls.30.dylib` (TLS, used by secur32/
+bcrypt). Those names are resolved via DYLD_FALLBACK_LIBRARY_PATH, which the
+launcher points at `lib/external` first (see BNetLauncher.swift). If no
+x86_64 build of these libs is found there, dyld falls back to /usr/local/lib
+— i.e. an *Intel* Homebrew install. Apple Silicon users who only have ARM
+Homebrew (/opt/homebrew) get nothing, so Battle.net Setup renders blank text
+(no FreeType) and downloads fail (no GnuTLS).
+
+Shipping x86_64 builds of the whole chain inside lib/external fixes this for
+every Apple Silicon user, with no Intel Homebrew required.
+
+Where the dylibs come from
+--------------------------
+Homebrew stopped publishing x86_64 ("Intel") bottles for current formula
+versions — `brew fetch --bottle-tag=sonoma` now reports "unavailable". But
+Homebrew's GHCR bottle registry keeps every historical bottle permanently
+(content-addressed), and current formulae still have x86_64 macOS bottles
+sitting there even when the local formula DSL no longer references them. So
+we fetch the bottles straight from ghcr.io with an anonymous token — no
+Homebrew needed on the build machine at all.
+
+What gets staged
+----------------
+We fetch the proven formula set, extract every bottle, then BFS the dylib
+dependency graph starting from the two libraries Wine actually dlopen()s and
+copy only the reachable x86_64 dylibs. Each copied dylib gets its install id
+and every Homebrew dependency path rewritten to `@rpath/<leaf>` so dyld
+resolves the whole chain out of lib/external (via DYLD_FALLBACK). System libs
+(/usr/lib, /System) are left untouched. A missing leaf is a hard error — that
+surfaces a new dependency (e.g. a future brotli requirement) instead of
+silently shipping a broken chain.
+"""
+
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib.request
+
+# Formulae whose x86_64 bottles supply the FreeType + GnuTLS dependency chain.
+FORMULAE = [
+    "freetype",
+    "gnutls",
+    "libpng",
+    "gmp",
+    "libtasn1",
+    "nettle",
+    "gettext",
+    "p11-kit",
+    "libidn2",
+    "libunistring",
+]
+
+# The libraries Wine dlopen()s by bare leaf name (confirmed via `strings` on
+# win32u.so / secur32.so / bcrypt.so). Everything else is pulled in as a
+# transitive dependency by the BFS closure below.
+SEEDS = ["libfreetype.6.dylib", "libgnutls.30.dylib"]
+
+# x86_64 macOS bottle tags, preferred newest-first. We never want arm64_* or
+# *_linux. A formula's newest version usually still has one of these on GHCR.
+X86_OS = ["sequoia", "sonoma", "ventura", "monterey", "big_sur", "catalina"]
+
+GHCR = "https://ghcr.io/v2/homebrew/core"
+HOMEBREW_PREFIXES = ("@@HOMEBREW", "/opt/homebrew", "/usr/local")
+
+
+def _token(formula):
+    url = (
+        f"https://ghcr.io/token?service=ghcr.io"
+        f"&scope=repository:homebrew/core/{formula}:pull"
+    )
+    return json.load(urllib.request.urlopen(url))["token"]
+
+
+def _get(url, tok, accept):
+    req = urllib.request.Request(
+        url, headers={"Authorization": f"Bearer {tok}", "Accept": accept}
+    )
+    return urllib.request.urlopen(req)
+
+
+def _pick_x86_bottle(formula, tok):
+    """Newest version of `formula` that has an x86_64 macOS bottle on GHCR.
+
+    Returns (version, os_tag, blob_layer_digest).
+    """
+    tags = json.load(_get(f"{GHCR}/{formula}/tags/list", tok, "application/json"))[
+        "tags"
+    ]
+    for version in reversed(tags):  # tags come oldest-first; want newest
+        try:
+            index = json.load(
+                _get(
+                    f"{GHCR}/{formula}/manifests/{version}",
+                    tok,
+                    "application/vnd.oci.image.index.v1+json",
+                )
+            )
+        except Exception:
+            continue
+        avail = {}
+        for m in index.get("manifests", []):
+            tag = m.get("annotations", {}).get("org.opencontainers.image.ref.name", "")
+            avail[tag] = m["digest"]
+        for os_tag in X86_OS:
+            for tag, digest in avail.items():
+                if tag.endswith("." + os_tag):
+                    manifest = json.load(
+                        _get(
+                            f"{GHCR}/{formula}/manifests/{digest}",
+                            tok,
+                            "application/vnd.oci.image.manifest.v1+json",
+                        )
+                    )
+                    return version, os_tag, manifest["layers"][0]["digest"]
+    raise SystemExit(f"error: no x86_64 macOS bottle for {formula} on GHCR")
+
+
+def fetch_and_extract(formula, cache, extract_root):
+    tok = _token(formula)
+    version, os_tag, layer = _pick_x86_bottle(formula, tok)
+    tgz = os.path.join(cache, f"{formula}-{version}.{os_tag}.tar.gz")
+    if not os.path.exists(tgz):
+        with _get(
+            f"{GHCR}/{formula}/blobs/{layer}", tok, "application/octet-stream"
+        ) as r, open(tgz, "wb") as f:
+            shutil.copyfileobj(r, f)
+    with tarfile.open(tgz) as t:
+        try:
+            t.extractall(extract_root, filter="data")  # py3.12+
+        except TypeError:
+            t.extractall(extract_root)
+    print(f"  {formula:12} {version}.{os_tag}  ({os.path.getsize(tgz)//1024} KB)")
+
+
+def real_dylibs(extract_root):
+    """Map every dylib leaf name -> its real (symlink-resolved) path across
+    all bottles. Sonames like libnettle.9.dylib are usually symlinks to a
+    fully-versioned file (libnettle.9.0.dylib); dependents reference the
+    soname, so we key on both and resolve to the real bytes."""
+    out = {}
+    for path in glob.glob(f"{extract_root}/*/*/lib/*.dylib"):
+        out[os.path.basename(path)] = os.path.realpath(path)
+    return out
+
+
+def deps(dylib):
+    """Non-system dependency leaf names of a Mach-O dylib."""
+    txt = subprocess.run(["otool", "-L", dylib], capture_output=True, text=True).stdout
+    result = []
+    for line in txt.splitlines()[1:]:
+        path = line.strip().split(" ")[0]
+        if path.startswith(HOMEBREW_PREFIXES):
+            result.append(os.path.basename(path))
+    return result
+
+
+def closure(seeds, table):
+    """BFS the dependency graph; return the set of leaf names to ship."""
+    need, queue = set(), list(seeds)
+    while queue:
+        leaf = queue.pop()
+        if leaf in need:
+            continue
+        if leaf not in table:
+            raise SystemExit(
+                f"error: dependency {leaf} not provided by any fetched "
+                f"bottle — add the formula that ships it to FORMULAE"
+            )
+        need.add(leaf)
+        queue.extend(deps(table[leaf]))
+    return need
+
+
+def rewrite(dylib):
+    """Set id and Homebrew deps to @rpath/<leaf> so dyld resolves from
+    lib/external. Leaves /usr/lib and /System references alone."""
+    leaf = os.path.basename(dylib)
+    subprocess.run(
+        ["install_name_tool", "-id", f"@rpath/{leaf}", dylib], capture_output=True
+    )
+    txt = subprocess.run(["otool", "-L", dylib], capture_output=True, text=True).stdout
+    for line in txt.splitlines()[1:]:
+        path = line.strip().split(" ")[0]
+        if path.startswith(HOMEBREW_PREFIXES):
+            base = os.path.basename(path)
+            subprocess.run(
+                ["install_name_tool", "-change", path, f"@rpath/{base}", dylib],
+                capture_output=True,
+            )
+
+
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    out_dir = (
+        sys.argv[1] if len(sys.argv) > 1 else os.path.join(script_dir, "wine-libs")
+    )
+    cache = os.path.join(out_dir, ".cache")
+    extract_root = os.path.join(cache, "extract")
+    shutil.rmtree(extract_root, ignore_errors=True)
+    os.makedirs(extract_root, exist_ok=True)
+    os.makedirs(out_dir, exist_ok=True)
+
+    print("==> fetching x86_64 bottles from GHCR")
+    for formula in FORMULAE:
+        fetch_and_extract(formula, cache, extract_root)
+
+    table = real_dylibs(extract_root)
+    need = sorted(closure(SEEDS, table))
+    print(f"==> staging {len(need)} dylibs (closure of {', '.join(SEEDS)})")
+
+    for leaf in need:
+        dst = os.path.join(out_dir, leaf)
+        shutil.copy(table[leaf], dst)
+        os.chmod(dst, 0o644)
+        rewrite(dst)
+        arch = subprocess.run(
+            ["file", "-b", dst], capture_output=True, text=True
+        ).stdout
+        tag = "x86_64" if "x86_64" in arch else "??ARCH??"
+        print(f"  {leaf:24} [{tag}]")
+
+    shutil.rmtree(cache, ignore_errors=True)
+    print(f"\n✓ wine libs staged in {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Prereqs/fetch.sh
+++ b/Prereqs/fetch.sh
@@ -18,7 +18,7 @@ for url in "${urls[@]}"; do
     echo "have: $name ($(stat -f %z "$name") bytes)"
     continue
   fi
-  echo "fetching $name…"
+  echo "fetching ${name}..."
   curl -L -o "$name" "$url"
 done
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ for the full breakdown.
 
 ## Status
 
-| Game / app | Status |
-|---|---|
-| Battle.net | ✓ launches, login + chat work, keyboard works |
-| Diablo IV | ✓ playable end-to-end (verified 2026-05) |
-| First-launch shader compile | ⚠ ~50 % of the time it hangs once on the Metal pipeline race; second launch always works |
-| Other Blizzard titles | not tested — try and [open an issue](https://github.com/MichaelLod/D4Mac/issues/new/choose) |
+| Game / app                  | Status                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------- |
+| Battle.net                  | ✓ launches, login + chat work, keyboard works                                               |
+| Diablo IV                   | ✓ playable end-to-end (verified 2026-05)                                                    |
+| First-launch shader compile | ⚠ ~50 % of the time it hangs once on the Metal pipeline race; second launch always works    |
+| Other Blizzard titles       | not tested — try and [open an issue](https://github.com/MichaelLod/D4Mac/issues/new/choose) |
 
 ## Requirements
 
@@ -65,6 +65,8 @@ git clone https://github.com/MichaelLod/D4Mac.git
 cd D4Mac
 Resources/Fonts/fetch.sh   # downloads MS Core Fonts (one-time)
 Prereqs/fetch.sh           # downloads VC++ Redistributable (one-time)
+# build.sh also auto-runs Prereqs/fetch-wine-libs.py to stage the x86_64
+# FreeType/GnuTLS chain into the Wine runtime (one-time, ~8 MB from GHCR).
 ./build.sh                 # debug build
 ./build.sh --release       # optimised
 ./build.sh --release --notarize --dmg   # full release pipeline
@@ -102,24 +104,25 @@ manipulation, no admin password.
 
 ## Repository layout
 
-| Path | Purpose |
-|---|---|
-| `Sources/D4Mac/` | SwiftUI launcher source |
-| `Resources/` | App icon, `Info.plist`, fonts, entitlements |
-| `Resources/Fonts/fetch.sh` | One-time fetch of MS Core Fonts For The Web |
-| `Prereqs/fetch.sh` | One-time fetch of VC++ Redistributable installers |
-| `web/` | The [d4mac.com](https://d4mac.com) Next.js site (download landing page, BMC tip checkout, dashboard) |
-| `build.sh` | Build / notarise / DMG packaging |
-| `THIRD_PARTY_LICENSES.md` | Per-component licence breakdown |
-| `LICENSE` | MIT — for the launcher source only |
+| Path                         | Purpose                                                                                              |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `Sources/D4Mac/`             | SwiftUI launcher source                                                                              |
+| `Resources/`                 | App icon, `Info.plist`, fonts, entitlements                                                          |
+| `Resources/Fonts/fetch.sh`   | One-time fetch of MS Core Fonts For The Web                                                          |
+| `Prereqs/fetch.sh`           | One-time fetch of VC++ Redistributable installers                                                    |
+| `Prereqs/fetch-wine-libs.py` | Stages the x86_64 FreeType/GnuTLS chain into Wine's `lib/external` (GHCR bottles)                    |
+| `web/`                       | The [d4mac.com](https://d4mac.com) Next.js site (download landing page, BMC tip checkout, dashboard) |
+| `build.sh`                   | Build / notarise / DMG packaging                                                                     |
+| `THIRD_PARTY_LICENSES.md`    | Per-component licence breakdown                                                                      |
+| `LICENSE`                    | MIT — for the launcher source only                                                                   |
 
 ## Reporting issues
 
 Use [GitHub Issues](https://github.com/MichaelLod/D4Mac/issues/new/choose).
 Include:
 
-- macOS version (e.g. *14.5 Sonoma*)
-- Mac model (e.g. *MacBook Pro M3 Pro*)
+- macOS version (e.g. _14.5 Sonoma_)
+- Mac model (e.g. _MacBook Pro M3 Pro_)
 - D4Mac version (Settings → About)
 - Logs from `~/Library/Logs/D4Mac/`
 - Screenshots if you have them

--- a/Sources/D4Mac/BNetLauncher.swift
+++ b/Sources/D4Mac/BNetLauncher.swift
@@ -22,8 +22,20 @@ struct WineProcess {
         env["WINEPREFIX"] = prefix.path
         env["WINEDLLOVERRIDES"] = "winemenubuilder.exe=d;mscoree=d;mshtml=d"
         env["WINEDEBUG"] = "-all,err+seh"
-        env["WINEMSYNC"] = "1"
-        env["WINEESYNC"] = "1"
+
+        // Wine sync primitive, driven by the Settings "Synchronisation" toggle
+        // (UserDefaults key "syncStyle"; see SettingsView.SyncStyle). Defaults
+        // to "none" — and that default matters: esync/msync spin on userspace
+        // sync objects, and on macOS 26 / Apple Silicon under Rosetta that spin
+        // pegs a CPU core and starves Battle.net's downloader (~4 KB/s instead
+        // of multiple MB/s), besides risking gameplay freezes. With sync off the
+        // wineserver arbitrates sync calls — far slower in theory, far more
+        // reliable here. Users who want the throughput can opt back into esync.
+        switch UserDefaults.standard.string(forKey: "syncStyle") ?? "none" {
+        case "msync": env["WINEMSYNC"] = "1"; env["WINEESYNC"] = "1"
+        case "esync": env["WINEMSYNC"] = "0"; env["WINEESYNC"] = "1"
+        default:      env["WINEMSYNC"] = "0"; env["WINEESYNC"] = "0"  // "none"
+        }
 
         // CrossOver-compatible runtime knobs (CW Wine source patches read these).
         env["CX_ACTIVE_GRAPHICS_BACKEND"] = "d3dmetal"

--- a/Sources/D4Mac/BottleManager.swift
+++ b/Sources/D4Mac/BottleManager.swift
@@ -58,6 +58,19 @@ final class BottleManager: ObservableObject {
     @Published var phase: Phase = .idle
     @Published var lastError: String?
 
+    /// Live progress for the Battle.net install, parsed from the Blizzard
+    /// Agent log while `phase == .runningInstaller`. nil when no figure is
+    /// available yet (early prefix/prereq phases, or before the Agent starts
+    /// reporting). Drives the determinate bar in the status banner.
+    @Published var installProgress: InstallProgress?
+
+    struct InstallProgress: Equatable {
+        var fraction: Double      // 0…1, the Agent's "playable_progress"
+        var bytesDone: Int64
+        var bytesTotal: Int64
+        var bytesPerSec: Double   // smoothed over the last poll interval
+    }
+
     /// Backwards-compat for the simple `disabled` checks.
     var isBusy: Bool { phase != .idle }
 
@@ -328,12 +341,15 @@ final class BottleManager: ObservableObject {
     /// Run an arbitrary BNet installer .exe inside the bottle. Used for
     /// initial setup. Returns when wine subprocess exits.
     func runInstaller(_ installerURL: URL) async {
-        defer { phase = .idle }
+        var progressTask: Task<Void, Never>?
+        defer { phase = .idle; installProgress = nil; progressTask?.cancel() }
         do {
             try await ensureBottle()
             try checkInstallerFile(installerURL)
 
             phase = .runningInstaller
+            installProgress = nil
+            progressTask = Task { [weak self] in await self?.pollInstallProgress() }
             log.info("running installer: \(installerURL.path)")
 
             // Battle.net-Setup.exe also uses CEF for its UI — same env-var
@@ -378,6 +394,88 @@ final class BottleManager: ObservableObject {
         } catch {
             lastError = error.localizedDescription
         }
+    }
+
+    // MARK: - Install progress (Blizzard Agent log)
+
+    /// Poll the Agent log ~every 1.5 s and publish a live progress figure.
+    /// Runs concurrently with the installer subprocess; cancelled when it exits.
+    private func pollInstallProgress() async {
+        var lastBytes: Int64 = 0
+        var lastTime = Date()
+        var primed = false
+        while !Task.isCancelled {
+            if let s = currentAgentStats() {
+                let now = Date()
+                let dt = now.timeIntervalSince(lastTime)
+                var speed = 0.0
+                // Skip the first sample (no baseline) and any counter reset
+                // (the byte counter restarts between agent-update and client
+                // phases — a negative delta isn't a real rate).
+                if primed, dt > 0, s.done >= lastBytes {
+                    speed = Double(s.done - lastBytes) / dt
+                }
+                installProgress = InstallProgress(
+                    fraction: s.fraction, bytesDone: s.done,
+                    bytesTotal: s.total, bytesPerSec: speed)
+                lastBytes = s.done
+                lastTime = now
+                primed = true
+            }
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+        }
+    }
+
+    /// Parse the newest Agent log's most recent progress blob.
+    private func currentAgentStats() -> (done: Int64, total: Int64, fraction: Double)? {
+        guard let logURL = newestAgentLog(), let tail = tailString(logURL) else { return nil }
+        let doneStr = lastCapture(#""update_bytes_current":\s*\[\s*([0-9]+)"#, tail)
+        let totalStr = lastCapture(#""update_bytes_total":\s*\[\s*([0-9]+)"#, tail)
+        let fracStr = lastCapture(#""playable_progress":\s*([0-9.]+)"#, tail)
+        if doneStr == nil && totalStr == nil && fracStr == nil { return nil }
+        let done = Int64(doneStr ?? "") ?? 0
+        let total = Int64(totalStr ?? "") ?? 0
+        let frac = Double(fracStr ?? "") ?? (total > 0 ? Double(done) / Double(total) : 0)
+        return (done, total, min(max(frac, 0), 1))
+    }
+
+    /// Newest `Agent-*.log` under the bottle's Battle.net Agent dir, by mtime.
+    private func newestAgentLog() -> URL? {
+        let agentDir = bottleRoot.appendingPathComponent(
+            "drive_c/ProgramData/Battle.net/Agent", isDirectory: true)
+        let fm = FileManager.default
+        guard let en = fm.enumerator(
+            at: agentDir, includingPropertiesForKeys: [.contentModificationDateKey]) else { return nil }
+        var best: (url: URL, date: Date)?
+        for case let u as URL in en {
+            let name = u.lastPathComponent
+            guard name.hasPrefix("Agent-"), name.hasSuffix(".log") else { continue }
+            let m = (try? u.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            if best == nil || m > best!.date { best = (u, m) }
+        }
+        return best?.url
+    }
+
+    /// Last `maxBytes` of a file as UTF-8 (the log only grows; the tail holds
+    /// the freshest progress blob).
+    private func tailString(_ url: URL, maxBytes: UInt64 = 65536) -> String? {
+        guard let fh = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? fh.close() }
+        let size = (try? fh.seekToEnd()) ?? 0
+        try? fh.seek(toOffset: size > maxBytes ? size - maxBytes : 0)
+        let data = (try? fh.readToEnd()) ?? Data()
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// First capture group of the LAST regex match (the most recent value).
+    private func lastCapture(_ pattern: String, _ s: String) -> String? {
+        guard let re = try? NSRegularExpression(
+            pattern: pattern, options: [.dotMatchesLineSeparators]) else { return nil }
+        let matches = re.matches(in: s, range: NSRange(s.startIndex..., in: s))
+        guard let last = matches.last, last.numberOfRanges > 1,
+              let r = Range(last.range(at: 1), in: s) else { return nil }
+        return String(s[r])
     }
 
     private func checkInstallerFile(_ url: URL) throws {

--- a/Sources/D4Mac/ContentView.swift
+++ b/Sources/D4Mac/ContentView.swift
@@ -193,6 +193,15 @@ struct ContentView: View {
                     .font(.caption)
                     .foregroundStyle(Color.appSubhead)
                     .fixedSize(horizontal: false, vertical: true)
+                if let p = bottle.installProgress, bottle.phase == .runningInstaller {
+                    ProgressView(value: p.fraction)
+                        .tint(.bnetBlueLight)
+                        .padding(.top, 4)
+                    Text(progressLine(p))
+                        .font(.caption2)
+                        .monospacedDigit()
+                        .foregroundStyle(Color.appCaption)
+                }
             }
             Spacer(minLength: 0)
         }
@@ -224,6 +233,21 @@ struct ContentView: View {
         let v = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0"
         let b = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "1"
         return "v\(v) (\(b))"
+    }
+
+    /// "67% · 1.2 GB / 1.8 GB · 8.3 MB/s" — bytes/speed dropped when unknown.
+    private func progressLine(_ p: BottleManager.InstallProgress) -> String {
+        let bcf = ByteCountFormatter()
+        bcf.allowedUnits = [.useGB, .useMB]
+        bcf.countStyle = .file
+        var parts = ["\(Int((p.fraction * 100).rounded()))%"]
+        if p.bytesTotal > 0 {
+            parts.append("\(bcf.string(fromByteCount: p.bytesDone)) / \(bcf.string(fromByteCount: p.bytesTotal))")
+        }
+        if p.bytesPerSec > 0 {
+            parts.append("\(bcf.string(fromByteCount: Int64(p.bytesPerSec)))/s")
+        }
+        return parts.joined(separator: " · ")
     }
 
     private func handleInstallerPick(_ result: Result<[URL], Error>) {

--- a/Sources/D4Mac/Settings.swift
+++ b/Sources/D4Mac/Settings.swift
@@ -4,16 +4,20 @@ struct SettingsView: View {
     @EnvironmentObject var bottle: BottleManager
     @AppStorage("metalHUD") private var metalHUD = false
     @AppStorage("vendorSpoof") private var vendorSpoof = true
-    @AppStorage("syncStyle") private var syncStyle: SyncStyle = .msync
+    @AppStorage("syncStyle") private var syncStyle: SyncStyle = .none
 
+    // Order = display order in the segmented picker. `none` is first and the
+    // default: on macOS 26 / Apple Silicon, esync/msync spin-wait pegs a CPU
+    // core and throttles Battle.net's downloader to a few KB/s (and can freeze
+    // gameplay). Read by WineProcess.environment in BNetLauncher.swift.
     enum SyncStyle: String, CaseIterable, Identifiable {
-        case msync, esync, none
+        case none, esync, msync
         var id: String { rawValue }
         var label: String {
             switch self {
-            case .msync: "MSync (recommended)"
+            case .none:  "None (recommended)"
             case .esync: "ESync"
-            case .none:  "None"
+            case .msync: "MSync"
             }
         }
     }
@@ -41,6 +45,9 @@ struct SettingsView: View {
                     ForEach(SyncStyle.allCases) { s in Text(s.label).tag(s) }
                 }
                 .pickerStyle(.segmented)
+                Text("Keep this on None on macOS 26 / Apple Silicon. ESync/MSync spin-wait on the CPU, which throttles Battle.net downloads to a crawl and can freeze the game. Takes effect the next time you launch Battle.net.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -6,6 +6,7 @@ the following third-party components, each retaining its own licence.
 ## Apple Game Porting Toolkit 3.0
 
 **Files in bundle**:
+
 - `Contents/SharedSupport/Wine/lib/external/D3DMetal.framework/`
 - `Contents/SharedSupport/Wine/lib/external/libd3dshared.dylib`
 - `Contents/SharedSupport/Wine/lib/wine/x86_64-windows/d3d12.dll`
@@ -16,7 +17,7 @@ the following third-party components, each retaining its own licence.
 - `Contents/SharedSupport/Wine/lib/wine/x86_64-windows/nvngx.dll`
 
 **Licence**: Apple GPTK Licence, redistributable per clause (i)(iii)
-*"distribute the Apple Software solely for non-commercial purposes."*
+_"distribute the Apple Software solely for non-commercial purposes."_
 The unmodified `License.pdf` is included in `Contents/Resources/` per
 that clause's requirements.
 
@@ -31,6 +32,7 @@ permits.
 
 **Files in bundle**: everything else under `Contents/SharedSupport/Wine/`,
 notably:
+
 - `bin/{wine, wineserver, wineloader, …}`
 - `lib/wine/x86_64-windows/wined3d.dll` and other Wine PE modules
 - `lib/wine/x86_64-unix/{ntdll, kernel32, …}.so`
@@ -58,6 +60,7 @@ it but bundling allows games that prefer Vulkan/MoltenVK to run.
 ## Microsoft Visual C++ 2015-2022 Redistributable
 
 **Files in bundle**:
+
 - `Contents/Resources/Prereqs/vc_redist.x86.exe`
 - `Contents/Resources/Prereqs/vc_redist.x64.exe`
 
@@ -116,6 +119,7 @@ available in the bottle.
 ## DXMT v0.72
 
 **Files in bundle**:
+
 - `Contents/SharedSupport/Wine/lib/external/dxmt/i386-windows/{d3d11,d3d10core,dxgi,winemetal}.dll`
 - `Contents/SharedSupport/Wine/lib/external/dxmt/x86_64-windows/{d3d11,d3d10core,dxgi,winemetal,nvapi64,nvngx}.dll`
 - `Contents/SharedSupport/Wine/lib/external/dxmt/x86_64-unix/winemetal.so`
@@ -135,3 +139,45 @@ ship v0.72 to keep the MIT terms.
 
 **Source**: [github.com/3Shain/dxmt](https://github.com/3Shain/dxmt) at
 the v0.72 tag.
+
+## FreeType / GnuTLS x86_64 dependency chain
+
+**Files in bundle**: `Contents/SharedSupport/Wine/lib/external/`
+
+- `libfreetype.6.dylib`, `libpng16.16.dylib`
+- `libgnutls.30.dylib`, `libnettle.9.dylib`, `libhogweed.7.dylib`,
+  `libgmp.10.dylib`, `libtasn1.6.dylib`, `libp11-kit.0.dylib`,
+  `libidn2.0.dylib`, `libunistring.5.dylib`, `libintl.8.dylib`
+
+**Why bundled**: the x86_64 Wine runtime `dlopen()`s these libraries by
+leaf name at runtime (FreeType for text rendering, GnuTLS for TLS) and
+resolves them out of `lib/external` via `DYLD_FALLBACK_LIBRARY_PATH`.
+Without an x86_64 build present, Apple Silicon users with only ARM
+Homebrew — or no Homebrew — saw blank text in Battle.net Setup and TLS
+failures. Bundling the whole closure removes the Intel-Homebrew dependency.
+
+**Modifications**: unmodified library code. Only Mach-O install names and
+inter-library dependency paths were rewritten to `@rpath/<leaf>` (via
+`install_name_tool`) so dyld resolves the chain from `lib/external`. No
+compiled code is altered.
+
+**Licences** (all free / redistributable; libraries are dynamically loaded,
+so the LGPL relinking provision is satisfiable):
+
+| Library                            | Upstream                                                                    | Licence                               |
+| ---------------------------------- | --------------------------------------------------------------------------- | ------------------------------------- |
+| FreeType (`libfreetype`)           | [freetype.org](https://freetype.org)                                        | FTL or GPL-2.0-or-later               |
+| libpng (`libpng16`)                | [libpng.org](http://www.libpng.org/pub/png/libpng.html)                     | PNG Reference Library License v2      |
+| GnuTLS (`libgnutls`)               | [gnutls.org](https://www.gnutls.org)                                        | LGPL-2.1-or-later                     |
+| Nettle (`libnettle`, `libhogweed`) | [lysator.liu.se/~nisse/nettle](https://www.lysator.liu.se/~nisse/nettle/)   | LGPL-3.0-or-later or GPL-2.0-or-later |
+| GMP (`libgmp`)                     | [gmplib.org](https://gmplib.org)                                            | LGPL-3.0-or-later or GPL-2.0-or-later |
+| libtasn1 (`libtasn1`)              | [gnu.org/software/libtasn1](https://www.gnu.org/software/libtasn1/)         | LGPL-2.1-or-later                     |
+| p11-kit (`libp11-kit`)             | [p11-glue.github.io](https://p11-glue.github.io/p11-glue/p11-kit.html)      | BSD-3-Clause                          |
+| libidn2 (`libidn2`)                | [gnu.org/software/libidn](https://www.gnu.org/software/libidn/)             | LGPL-3.0-or-later or GPL-2.0-or-later |
+| libunistring (`libunistring`)      | [gnu.org/software/libunistring](https://www.gnu.org/software/libunistring/) | LGPL-3.0-or-later or GPL-2.0-or-later |
+| gettext runtime (`libintl`)        | [gnu.org/software/gettext](https://www.gnu.org/software/gettext/)           | LGPL-2.1-or-later                     |
+
+**Source**: prebuilt x86_64 macOS bottles from Homebrew's GHCR registry
+(`ghcr.io/homebrew/core/*`), staged by `Prereqs/fetch-wine-libs.py`. The
+complete corresponding source for each library is available from its
+upstream above and from [github.com/Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core).

--- a/build.sh
+++ b/build.sh
@@ -120,6 +120,28 @@ cp -cR "$WINE_RUNTIME" "$APP/Contents/SharedSupport/Wine"
 find "$APP/Contents/SharedSupport/Wine" \
   \( -name "*.bak" -o -name "*.before-*" \) -delete
 
+# Bundled x86_64 FreeType/GnuTLS chain. Wine dlopen()s these libraries by
+# bare leaf name (libfreetype.6.dylib, libgnutls.30.dylib, …) and resolves
+# them out of lib/external via DYLD_FALLBACK_LIBRARY_PATH (see
+# BNetLauncher.swift). Without them, Apple Silicon users who have only ARM
+# Homebrew — or none at all — get blank text in Battle.net Setup (no FreeType)
+# and TLS failures (no GnuTLS), because dyld's only fallback was an Intel
+# Homebrew under /usr/local/lib. Fetched on demand from Homebrew's GHCR bottle
+# registry (no Homebrew required) — see Prereqs/fetch-wine-libs.py.
+WINELIBS_SRC="$SCRIPT_DIR/Prereqs/wine-libs"
+WINELIBS_DST="$APP/Contents/SharedSupport/Wine/lib/external"
+if [ ! -f "$WINELIBS_SRC/libfreetype.6.dylib" ]; then
+  echo "==> fetching x86_64 Wine support libs (one-time, ~8 MB)"
+  /usr/bin/python3 "$SCRIPT_DIR/Prereqs/fetch-wine-libs.py"
+fi
+if [ -f "$WINELIBS_SRC/libfreetype.6.dylib" ]; then
+  mkdir -p "$WINELIBS_DST"
+  cp -p "$WINELIBS_SRC"/*.dylib "$WINELIBS_DST/"
+  echo "bundled wine libs ($(ls "$WINELIBS_SRC"/*.dylib | wc -l | tr -d ' ') x86_64 dylibs)"
+else
+  echo "warning: $WINELIBS_SRC missing — FreeType/GnuTLS won't be bundled"
+fi
+
 # Make sure binaries are executable post-copy.
 chmod +x "$APP/Contents/MacOS/D4Mac"
 find "$APP/Contents/SharedSupport/Wine/bin" -type f -exec chmod +x {} +


### PR DESCRIPTION
Fixes the Apple Silicon install/login breakage reported in #2, plus two related problems found while reproducing it.

## Background

On Apple Silicon Macs with only ARM Homebrew (or none), the bundled x86_64 Wine `dlopen()`s `libfreetype.6.dylib` and `libgnutls.30.dylib` by leaf name and finds nothing — the only `DYLD_FALLBACK_LIBRARY_PATH` fallback was an Intel Homebrew at `/usr/local/lib`. Result: blank text in Battle.net Setup and Schannel/TLS failures during install (#2).

## Changes

### 1. Bundle the x86_64 FreeType/GnuTLS chain — `feat(wine)`

`Prereqs/fetch-wine-libs.py` fetches the x86_64 macOS bottles **straight from Homebrew's GHCR registry** — no Homebrew needed on the build machine, and it still works even though the `sonoma` bottles `brew fetch --bottle-tag=sonoma` used to serve have since been dropped upstream. It BFS-resolves the dependency closure from the two libraries Wine actually `dlopen()`s, rewrites install ids + Homebrew dep paths to `@rpath/…`, and stages 11 dylibs. `build.sh` copies them into `Contents/SharedSupport/Wine/lib/external`, where `DYLD_FALLBACK_LIBRARY_PATH` already points. Licences documented in `THIRD_PARTY_LICENSES.md`; fetched-on-demand (gitignored), matching the existing fonts / VC-redist pattern.

Verified locally: all 11 are x86_64, no residual Homebrew paths remain, and `libfreetype.6.dylib` + `libgnutls.30.dylib` `dlopen()` cleanly (whole transitive chain) under Rosetta out of `lib/external`.

### 2. Default the Wine sync primitive to "none" + wire the Settings toggle — `fix(wine)`

`WINEMSYNC=1`/`WINEESYNC=1` were hardcoded, and the Settings → "Synchronisation" picker (`syncStyle`) was never read anywhere. On macOS 26 / Apple Silicon under Rosetta, esync/msync spin-wait pegs a CPU core.

**New finding beyond #2:** this doesn't only freeze D4 gameplay (as the #2 comments describe) — it also throttles the Battle.net **installer download** from multiple MB/s to a crawl. Measured on an M-series Mac mid-repro: native link **5.6 MB/s**, BNet download **~4 KB/s** with `Battle.net-Setup.exe` pegging a full core; relaunching the exact same install with `WINEMSYNC=0 WINEESYNC=0` jumped it to **~8 MB/s** (≈2000×) and it finished in seconds.

`WineProcess.environment` now reads the `syncStyle` UserDefaults key (covering both the installer and the launcher) and defaults to `none`. The picker now defaults to / recommends `None` with an explanatory caption.

### 3. Live install progress — `feat(ui)`

During install the UI only showed a spinner + "look for the installer window" until it flipped to Launch at the very end, so a healthy (or throttled) install looked dead — which is exactly what made the throttle above so confusing. `BottleManager` now polls the Blizzard Agent log (`update_bytes_current/total`, `playable_progress`) ~every 1.5 s while the installer runs and publishes a determinate figure; `ContentView` shows a bar + "NN% · X GB / Y GB · Z MB/s". A visible speed readout would also have surfaced the 4 KB/s throttle immediately.

### 4. `fetch.sh` unbound-variable fix — `fix(prereqs)`

The `…` in `"fetching $name…"` glued the multibyte char onto the variable name under some locales, so `set -u` aborted with `name…: unbound variable`. Braced + ASCII `...`.

## Verification

`swift build` is green for all changed code. The pre-existing `#Preview` macros (`Settings.swift`, `BeerTip.swift`) require the full Xcode toolchain's macro plugin and fail under bare CommandLineTools — unrelated to this PR, and they were temporarily stubbed only to confirm the changed code compiles, then restored unchanged.

## Workaround until a build ships

Apple Silicon users can already avoid the throttle/freeze by setting **Settings → Synchronisation → None**, or by launching Battle.net externally with `WINEMSYNC=0 WINEESYNC=0` plus the existing `--in-process-gpu --use-gl=swiftshader` CEF flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added install progress tracking for Battle.net installations with real-time byte/speed metrics.

* **Bug Fixes**
  * Improved Wine runtime dependency management with automatic bundled library staging.

* **Documentation**
  * Updated build and licensing documentation for third-party dependencies; added sync style guidance for macOS compatibility.

* **Chores**
  * Optimized build script to auto-stage runtime libraries; changed default synchronization style to "None."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->