### PR TITLE
fix: wire the metalHUD + vendorSpoof Settings toggles into the Wine env

### DIFF
--- a/Sources/D4Mac/BNetLauncher.swift
+++ b/Sources/D4Mac/BNetLauncher.swift
@@ -34,9 +34,25 @@ struct WineProcess {
         let existing = env["DYLD_FALLBACK_LIBRARY_PATH"] ?? "/usr/local/lib:/usr/lib"
         env["DYLD_FALLBACK_LIBRARY_PATH"] = "\(externalLibDir.path):\(existing)"
 
-        env["D3DM_VENDOR_ID"] = "0x106b"
-        env["D3DM_DEVICE_ID"] = "0x0209"
-        env["D3DM_DEVICE_DESCRIPTION"] = "Apple GPU"
+        // Settings toggles. WineProcess isn't @MainActor, so read UserDefaults
+        // directly (that's all @AppStorage is). Defaults here must match the
+        // @AppStorage defaults in SettingsView: vendorSpoof=true, metalHUD=false.
+        // (The syncStyle picker is wired separately — see the sync PR.)
+        let defaults = UserDefaults.standard
+        let vendorSpoof = defaults.object(forKey: "vendorSpoof") == nil
+            ? true : defaults.bool(forKey: "vendorSpoof")
+
+        // GPU vendor/device spoof so D4 takes the Apple-GPU path.
+        if vendorSpoof {
+            env["D3DM_VENDOR_ID"] = "0x106b"
+            env["D3DM_DEVICE_ID"] = "0x0209"
+            env["D3DM_DEVICE_DESCRIPTION"] = "Apple GPU"
+        }
+
+        // Apple's built-in Metal performance HUD (FPS / frame-time overlay).
+        if defaults.bool(forKey: "metalHUD") {
+            env["MTL_HUD_ENABLED"] = "1"
+        }
 
         for (k, v) in extraEnv { env[k] = v }
         return env

--- a/Sources/D4Mac/Settings.swift
+++ b/Sources/D4Mac/Settings.swift
@@ -32,9 +32,13 @@ struct SettingsView: View {
 
     private var generalTab: some View {
         Form {
-            Section("Performance") {
+            Section {
                 Toggle("Show Metal performance HUD", isOn: $metalHUD)
                 Toggle("Spoof GPU as Apple (recommended for D4)", isOn: $vendorSpoof)
+            } header: {
+                Text("Performance")
+            } footer: {
+                Text("Applied the next time you launch Battle.net.")
             }
             Section("Wine sync primitive") {
                 Picker("Synchronisation", selection: $syncStyle) {


### PR DESCRIPTION
## What

The `metalHUD` and `vendorSpoof` toggles already existed in Settings, but `WineProcess.environment` never read them — so they did nothing.

## Changes

- **Show Metal performance HUD** → sets `MTL_HUD_ENABLED=1` (Apple's built-in FPS / frame-time overlay). Off by default.
- **Spoof GPU as Apple** → gates the `D3DM_VENDOR_ID/DEVICE_ID/DESCRIPTION` block. On by default (matches the previous hardcoded behaviour).
- Adds a Performance section footer: *"Applied the next time you launch Battle.net."* — they're env vars set at Wine start, not live-toggleable.

Read straight from `UserDefaults` since `WineProcess` isn't `@MainActor`; defaults mirror the `@AppStorage` defaults.

Note: leaves the `syncStyle` picker alone to avoid a conflicting edit to the same function — that one's handled by the separate sync-primitive PR; happy to rebase on top of it.

## Testing

`swift build` clean; verified the HUD overlay appears when toggled on, via a local dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU vendor and device spoofing is now optional and configurable via settings
  * Metal HUD display can be toggled on or off

* **Style**
  * Performance settings section now includes footer messaging clarifying that changes take effect on next app launch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->