### PR TITLE
feat: "Reset launcher state" — one-click fix for Battle.net stuck on "Update — Queued"

### DIFF
--- a/Sources/D4Mac/BottleManager.swift
+++ b/Sources/D4Mac/BottleManager.swift
@@ -475,6 +475,41 @@ final class BottleManager: ObservableObject {
         state = .missing
     }
 
+    /// Non-destructive launcher-state reset. After any hard Wine quit (freeze
+    /// force-quit, crash), Battle.net's Agent often comes back with stale
+    /// `aggregate.json`/product-db state: the game tile shows "Update — Queued",
+    /// the button is dead, and Cancel/Pause do nothing (AgentErrors logs
+    /// "Failed to write aggregate title data"). Wiping the Agent's derived
+    /// state + the launcher caches forces a fresh disk scan on next launch —
+    /// keeps the logged-in account and all game files.
+    /// (Fix contributed by @0ximu in issue #2.)
+    func resetLauncherState() async {
+        await killWineProcesses()
+
+        let fm = FileManager.default
+        let driveC = bottleRoot.appendingPathComponent("drive_c", isDirectory: true)
+        let agent = driveC.appendingPathComponent("ProgramData/Battle.net/Agent", isDirectory: true)
+        let localBNet = driveC.appendingPathComponent(
+            "users/crossover/AppData/Local/Battle.net", isDirectory: true)
+
+        let targets = [
+            agent.appendingPathComponent("aggregate.json"),
+            agent.appendingPathComponent(".product.db"),
+            agent.appendingPathComponent(".product.db.new"),
+            agent.appendingPathComponent(".product.db.old"),
+            agent.appendingPathComponent("Agent.dat"),
+            agent.appendingPathComponent(".patch.result"),
+            localBNet.appendingPathComponent("Cache"),
+            localBNet.appendingPathComponent("BrowserCaches"),
+        ]
+        var removed = 0
+        for t in targets where fm.fileExists(atPath: t.path) {
+            do { try fm.removeItem(at: t); removed += 1 }
+            catch { log.warning("launcher reset: couldn't remove \(t.lastPathComponent): \(error.localizedDescription)") }
+        }
+        log.info("launcher state reset: removed \(removed) item(s)")
+    }
+
     /// `wineserver -k` for our prefix — terminates all Wine processes
     /// (BNet, Agent, GPU subprocesses, etc.) cleanly without touching other
     /// Wine prefixes on the system.

--- a/Sources/D4Mac/Settings.swift
+++ b/Sources/D4Mac/Settings.swift
@@ -57,6 +57,14 @@ struct SettingsView: View {
                 Button("Reveal in Finder") {
                     NSWorkspace.shared.open(bottle.bottleRoot)
                 }
+                LabeledContent("Battle.net stuck on “Update — Queued”?") {
+                    Button("Reset launcher state") {
+                        Task { await bottle.resetLauncherState() }
+                    }
+                    .disabled(bottle.isBusy)
+                }
+                Text("Clears the Blizzard Agent's cached state so the launcher re-scans your games. Non-destructive: keeps your login and all game files. Use after a freeze or force-quit leaves Battle.net confused.")
+                    .font(.caption).foregroundStyle(.secondary)
                 Button("Reset bottle…", role: .destructive) {
                     let alert = NSAlert()
                     alert.messageText = "Reset bottle?"


### PR DESCRIPTION
## What

One-click, **non-destructive** fix for the stuck Battle.net launcher state reported in #2: after any hard Wine quit (freeze force-quit, crash), the game tile shows **"Update — Queued"**, the Update button is dead, and Cancel/Pause/Resume do nothing. `AgentErrors-*.log` shows `Failed to write aggregate title data to 'C:/ProgramData/Battle.net/Agent/aggregate.json'`.

## How

**Settings → Advanced → "Reset launcher state"**: kills the prefix's Wine processes, then wipes only the Agent's derived state (`aggregate.json`, `.product.db*`, `Agent.dat`, `.patch.result`) and the launcher's `Cache`/`BrowserCaches`. On next launch Battle.net rebuilds its state from a fresh disk scan — **login and game files untouched**.

Exact wipe list contributed and validated by @0ximu in #2 (who suggested exactly this menu item). This just makes it a button.

## Testing

`swift build` clean; exercised via a local dev bundle against a real bottle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
