### PR TITLE
feat: "Move bottle…" — relocate all D4Mac data to a custom location (external SSD)

### DIFF
--- a/Sources/D4Mac/BottleManager.swift
+++ b/Sources/D4Mac/BottleManager.swift
@@ -24,6 +24,7 @@ final class BottleManager: ObservableObject {
         case installingPrereqs          // Microsoft VC++ runtime, etc.
         case runningInstaller           // BNet installer in Wine
         case launchingBattleNet         // Battle.net.exe running
+        case movingBottle               // relocating the support dir to another volume
 
         var label: String {
             switch self {
@@ -33,6 +34,7 @@ final class BottleManager: ObservableObject {
             case .installingPrereqs:  "Stoking the engine…"
             case .runningInstaller:   "Battle.net's moving in"
             case .launchingBattleNet: "Battle.net is live"
+            case .movingBottle:       "Relocating your bottle…"
             }
         }
 
@@ -50,6 +52,8 @@ final class BottleManager: ObservableObject {
                 "Look for the installer window — click through its prompts and D4Mac will take over once it's home."
             case .launchingBattleNet:
                 "Battle.net opened in its own window. Log in there and pick a game to play."
+            case .movingBottle:
+                "Copying everything to the new location. With games installed this can take a while — don't unplug the drive."
             }
         }
     }
@@ -473,6 +477,81 @@ final class BottleManager: ObservableObject {
         Task { await killWineProcesses() }
         try? FileManager.default.removeItem(at: bottleRoot)
         state = .missing
+    }
+
+    // MARK: - Move support dir (custom install location)
+
+    /// True when the standard support path is a symlink left by a prior move.
+    var supportDirIsRelocated: Bool {
+        (try? FileManager.default.destinationOfSymbolicLink(atPath: supportRoot.path)) != nil
+    }
+
+    /// Move the entire support dir (bottle, games, shader cache) into
+    /// `destParent`/D4Mac and leave a symlink at the standard
+    /// `~/Library/Application Support/D4Mac` path. Every code path keeps
+    /// resolving through the standard path, so nothing else changes — the
+    /// same approach @0ximu validated manually with an external SSD in
+    /// issue #2, minus the Terminal.
+    ///
+    /// Same-volume this is an instant rename; cross-volume Foundation copies
+    /// then deletes, which for a bottle with games installed takes a while.
+    func moveSupportDir(to destParent: URL) async {
+        defer { phase = .idle }
+        let fm = FileManager.default
+        let standard = supportRoot
+        let current = standard.resolvingSymlinksInPath()
+        let dest = destParent.appendingPathComponent("D4Mac", isDirectory: true)
+
+        guard fm.fileExists(atPath: current.path) else {
+            lastError = D4MacError(
+                "Nothing to move yet.",
+                "The bottle hasn't been created. Install Battle.net first, then move it."
+            ).fullMessage
+            return
+        }
+        guard dest.resolvingSymlinksInPath().path != current.path else {
+            lastError = D4MacError(
+                "It's already there.",
+                "The bottle already lives at \(dest.path)."
+            ).fullMessage
+            return
+        }
+        guard !dest.path.hasPrefix(current.path + "/") else {
+            lastError = D4MacError(
+                "Can't move the bottle into itself.",
+                "Pick a destination outside the current D4Mac data folder."
+            ).fullMessage
+            return
+        }
+        guard !fm.fileExists(atPath: dest.path) else {
+            lastError = D4MacError(
+                "There's already a D4Mac folder there.",
+                "Remove or rename \(dest.path) first, then try again."
+            ).fullMessage
+            return
+        }
+
+        phase = .movingBottle
+        await killWineProcesses()
+
+        do {
+            // Cross-volume moves copy + delete; run off the main actor so the
+            // UI stays responsive for the duration.
+            try await Task.detached(priority: .userInitiated) {
+                try FileManager.default.moveItem(at: current, to: dest)
+            }.value
+            // Drop a stale symlink from any earlier move (harmless no-op when
+            // the standard path was the real dir — it's gone after the move).
+            try? fm.removeItem(at: standard)
+            try fm.createSymbolicLink(at: standard, withDestinationURL: dest)
+            log.info("support dir moved to \(dest.path), symlink left at standard path")
+        } catch {
+            lastError = D4MacError(
+                "Couldn't move the bottle.",
+                "Moving to \(dest.path) failed: \(error.localizedDescription). Your data is either still at the old location or fully at the new one — nothing is half-copied on the same drive; check both if this was a cross-drive move."
+            ).fullMessage
+        }
+        await refresh()
     }
 
     /// `wineserver -k` for our prefix — terminates all Wine processes

--- a/Sources/D4Mac/Settings.swift
+++ b/Sources/D4Mac/Settings.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @AppStorage("metalHUD") private var metalHUD = false
     @AppStorage("vendorSpoof") private var vendorSpoof = true
     @AppStorage("syncStyle") private var syncStyle: SyncStyle = .msync
+    @State private var showMovePicker = false
 
     enum SyncStyle: String, CaseIterable, Identifiable {
         case msync, esync, none
@@ -28,6 +29,21 @@ struct SettingsView: View {
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
         .padding(20)
+        .fileImporter(
+            isPresented: $showMovePicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            guard case .success(let urls) = result, let dest = urls.first else { return }
+            let alert = NSAlert()
+            alert.messageText = "Move all D4Mac data?"
+            alert.informativeText = "Everything (bottle, installed games, shader cache) moves to \(dest.path)/D4Mac. Battle.net will be closed first. On another drive this copies all data — with games installed it can take a while."
+            alert.addButton(withTitle: "Move")
+            alert.addButton(withTitle: "Cancel")
+            if alert.runModal() == .alertFirstButtonReturn {
+                Task { await bottle.moveSupportDir(to: dest) }
+            }
+        }
     }
 
     private var generalTab: some View {
@@ -50,13 +66,19 @@ struct SettingsView: View {
         Form {
             Section("Bottle") {
                 LabeledContent("Location") {
-                    Text(bottle.bottleRoot.path)
+                    Text(bottle.bottleRoot.resolvingSymlinksInPath().path)
                         .font(.system(.caption, design: .monospaced))
                         .lineLimit(1).truncationMode(.middle)
                 }
                 Button("Reveal in Finder") {
-                    NSWorkspace.shared.open(bottle.bottleRoot)
+                    NSWorkspace.shared.open(bottle.bottleRoot.resolvingSymlinksInPath())
                 }
+                LabeledContent("Need the space elsewhere?") {
+                    Button("Move bottle…") { showMovePicker = true }
+                        .disabled(bottle.isBusy)
+                }
+                Text("Moves all D4Mac data (bottle, games, shader cache) to a folder you pick — e.g. an external SSD — and links it back invisibly. Games keep working; nothing to reinstall.")
+                    .font(.caption).foregroundStyle(.secondary)
                 Button("Reset bottle…", role: .destructive) {
                     let alert = NSAlert()
                     alert.messageText = "Reset bottle?"


### PR DESCRIPTION
## What

**Settings → Advanced → "Move bottle…"** — relocate all D4Mac data (bottle, installed games, shader cache) to a user-chosen folder, e.g. an external SSD. Blizzard installs are 90+ GB; plenty of Macs don't have that free internally. Requested by @0ximu in #2.

## How

Moves the entire support dir to `<chosen>/D4Mac` and leaves a **symlink** at the standard `~/Library/Application Support/D4Mac` path, so every existing code path keeps resolving through the standard location — games keep working, nothing to reinstall. This is exactly the manual symlink setup @0ximu validated on a Samsung T7 in #2, minus the Terminal.

- Same-volume: instant rename. Cross-volume: copy (runs off the main actor, with a status banner + confirmation alert warning it can take a while).
- Guards: no bottle yet · destination already occupied · moving into itself · already there.
- The Location row + "Reveal in Finder" now show the resolved (real) path.
- Battle.net is closed first (`wineserver -k`, scoped to the prefix).

## Testing

`swift build` clean; guards and picker exercised via a local dev bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to move D4Mac support data and bottle files to a folder you choose.
  * The app now shows clearer progress messages while the move is in progress.

* **Bug Fixes**
  * Improved bottle location handling so Finder opens the actual storage location.
  * Added checks to prevent invalid moves and reduce the chance of data placement errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->