### PR TITLE
fix: disable legacy recovery hooks on macOS 26.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ for the full breakdown.
 
 ## Known issues
 
-### Mid-game freeze on macOS ≤ 26.3 (Rosetta 2 deadlock)
+### Mid-game freeze on macOS < 26.5 (Rosetta 2 deadlock)
 
 After anywhere from a few minutes to several hours of play, the game can
 freeze unrecoverably and macOS shows a persistent beachball. This is a
-**Rosetta 2 deadlock**, not a Wine or D3DMetal bug — the wedged thread
-parks on `os_sync_wait_on_address` inside Apple's `libd3dshared.dylib`,
-triggered when Blizzard's anti-cheat reads translated x86_64 code pages.
-CodeWeavers [publicly confirmed](https://www.codeweavers.com/compatibility/crossover/forum/diablo-iv?msg=348207)
-this is an Apple-side bug — nothing the launcher can patch from the Wine
-side.
+**Rosetta 2 deadlock** — the wedged thread parks on
+`os_sync_wait_on_address` inside Apple's `libd3dshared.dylib`, triggered
+when Blizzard's anti-cheat reads translated x86_64 code pages. CodeWeavers
+[confirmed](https://www.codeweavers.com/blog/mjohnson/2026/5/18/finally-diablo-iv-and-overwatch-are-playable-with-crossover-261-macos-265)
+that both its Wine 26.1 changes and the Rosetta changes in macOS 26.5 are
+required.
 
-**Fix: upgrade to macOS 26.4 Tahoe (released 2026-03-24) or later.**
-Apple silently patched the underlying Rosetta 2 issue in 26.4. Users
-[report 1+ hour clean play sessions](https://www.codeweavers.com/compatibility/crossover/forum/diablo-iv?msg=349051)
-on 26.4 where 26.3 and earlier still freeze.
+**Fix: upgrade to macOS 26.5 Tahoe or later.** D4Mac already bundles a
+Wine 11.0 runtime based on the required CodeWeavers 26.1 sources. On 26.5
+and later, D4Mac also disables its legacy wait-kick automatically because
+the Rosetta workaround is no longer needed.
 
 If you can't upgrade yet, these mitigations reduce — but do not cure —
 the freeze frequency:
@@ -69,7 +69,7 @@ entirely.
 ## Requirements
 
 - Apple Silicon Mac (M1, M2, M3, M4 — any)
-- macOS 14 (Sonoma) or later — **macOS 26.4 Tahoe strongly recommended** for D4 stability (see [Known issues](#known-issues))
+- macOS 14 (Sonoma) or later — **macOS 26.5 Tahoe strongly recommended** for D4 stability (see [Known issues](#known-issues))
 - ~400 MB free for the `.app` bundle, plus space for the Battle.net + game install (Diablo IV is ~80 GB)
 - Apple ID (only if Gatekeeper prompts you to verify the bundle on first launch)
 

--- a/Sources/D4Mac/BNetLauncher.swift
+++ b/Sources/D4Mac/BNetLauncher.swift
@@ -183,8 +183,11 @@ extension BottleManager {
                 "ROSETTA_ADVERTISE_AVX": "1",
                 "DOTNET_EnableWriteXorExecute": "0"
             ]
-            if autokillEnabled {
-                baseEnv["D4_WATCHDOG_AUTOKILL"] = "1"
+            for (key, value) in WineCompatibilityPolicy.recoveryPatchEnvironment(
+                operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersion,
+                watchdogAutokillEnabled: autokillEnabled
+            ) {
+                baseEnv[key] = value
             }
 
             // Auto-relaunch loop: when the watchdog kills the process via

--- a/Sources/D4Mac/BNetLauncher.swift
+++ b/Sources/D4Mac/BNetLauncher.swift
@@ -183,12 +183,12 @@ extension BottleManager {
                 "ROSETTA_ADVERTISE_AVX": "1",
                 "DOTNET_EnableWriteXorExecute": "0"
             ]
-            for (key, value) in WineCompatibilityPolicy.recoveryPatchEnvironment(
-                operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersion,
-                watchdogAutokillEnabled: autokillEnabled
-            ) {
-                baseEnv[key] = value
-            }
+            baseEnv.merge(
+                WineCompatibilityPolicy.recoveryPatchEnvironment(
+                    operatingSystemVersion: ProcessInfo.processInfo.operatingSystemVersion,
+                    watchdogAutokillEnabled: autokillEnabled
+                )
+            ) { _, new in new }
 
             // Auto-relaunch loop: when the watchdog kills the process via
             // SIGKILL we briefly show a "Recovering from freeze…" status and

--- a/Sources/D4Mac/WineCompatibilityPolicy.swift
+++ b/Sources/D4Mac/WineCompatibilityPolicy.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Environment policy for the Wine-side Diablo IV recovery patches bundled
+/// with D4Mac.
+///
+/// The d4-kick/watchdog hooks were introduced to recover from a Rosetta 2
+/// deadlock on older Tahoe builds. CodeWeavers confirms that its workaround is
+/// no longer needed starting with macOS 26.5. Leaving the hooks armed on newer
+/// systems changes Windows wait semantics for no benefit and can destabilise
+/// otherwise healthy game sessions.
+enum WineCompatibilityPolicy {
+    static func recoveryPatchEnvironment(
+        operatingSystemVersion version: OperatingSystemVersion,
+        watchdogAutokillEnabled: Bool
+    ) -> [String: String] {
+        var environment: [String: String] = [:]
+
+        if hasRosettaDeadlockFix(version) {
+            environment["D4_KICK_DISABLE"] = "1"
+
+            if watchdogAutokillEnabled {
+                environment["D4_WATCHDOG_AUTOKILL"] = "1"
+            } else {
+                environment["D4_WATCHDOG_DISABLE"] = "1"
+            }
+        } else if watchdogAutokillEnabled {
+            environment["D4_WATCHDOG_AUTOKILL"] = "1"
+        }
+
+        return environment
+    }
+
+    private static func hasRosettaDeadlockFix(_ version: OperatingSystemVersion) -> Bool {
+        version.majorVersion > 26
+            || (version.majorVersion == 26 && version.minorVersion >= 5)
+    }
+}

--- a/Tests/WineCompatibilityPolicyCheck.swift
+++ b/Tests/WineCompatibilityPolicyCheck.swift
@@ -62,9 +62,11 @@ struct WineCompatibilityPolicyCheck {
         name: String,
         failures: inout Int
     ) {
-        guard actual != expected else { return }
-        failures += 1
-        fputs("FAIL \(name): got \(actual), expected \(expected)\n", stderr)
+        guard actual == expected else {
+            failures += 1
+            fputs("FAIL \(name): got \(actual), expected \(expected)\n", stderr)
+            return
+        }
     }
 
     private static func policy(

--- a/Tests/WineCompatibilityPolicyCheck.swift
+++ b/Tests/WineCompatibilityPolicyCheck.swift
@@ -1,0 +1,84 @@
+import Darwin
+import Foundation
+
+@main
+struct WineCompatibilityPolicyCheck {
+    static func main() {
+        var failures = 0
+
+        check(
+            policy(major: 26, minor: 3),
+            equals: [:],
+            name: "legacy Tahoe",
+            failures: &failures
+        )
+        check(
+            policy(major: 26, minor: 3, autokill: true),
+            equals: ["D4_WATCHDOG_AUTOKILL": "1"],
+            name: "legacy Tahoe with autokill",
+            failures: &failures
+        )
+        check(
+            policy(major: 26, minor: 4),
+            equals: [:],
+            name: "Tahoe 26.4",
+            failures: &failures
+        )
+        check(
+            policy(major: 26, minor: 5),
+            equals: [
+                "D4_KICK_DISABLE": "1",
+                "D4_WATCHDOG_DISABLE": "1",
+            ],
+            name: "fixed Tahoe",
+            failures: &failures
+        )
+        check(
+            policy(major: 26, minor: 5, autokill: true),
+            equals: [
+                "D4_KICK_DISABLE": "1",
+                "D4_WATCHDOG_AUTOKILL": "1",
+            ],
+            name: "fixed Tahoe with autokill",
+            failures: &failures
+        )
+        check(
+            policy(major: 27, minor: 0),
+            equals: [
+                "D4_KICK_DISABLE": "1",
+                "D4_WATCHDOG_DISABLE": "1",
+            ],
+            name: "future macOS",
+            failures: &failures
+        )
+
+        guard failures == 0 else { exit(EXIT_FAILURE) }
+        print("Wine compatibility policy checks passed")
+    }
+
+    private static func check(
+        _ actual: [String: String],
+        equals expected: [String: String],
+        name: String,
+        failures: inout Int
+    ) {
+        guard actual != expected else { return }
+        failures += 1
+        fputs("FAIL \(name): got \(actual), expected \(expected)\n", stderr)
+    }
+
+    private static func policy(
+        major: Int,
+        minor: Int,
+        autokill: Bool = false
+    ) -> [String: String] {
+        WineCompatibilityPolicy.recoveryPatchEnvironment(
+            operatingSystemVersion: OperatingSystemVersion(
+                majorVersion: major,
+                minorVersion: minor,
+                patchVersion: 0
+            ),
+            watchdogAutokillEnabled: autokill
+        )
+    }
+}


### PR DESCRIPTION
Refs #10.

## What changed

- add a small, testable `WineCompatibilityPolicy` for the bundled recovery hooks
- on macOS 26.5 and later, disable `d4-kick`; also disable the watchdog unless the user explicitly enabled watchdog autokill
- preserve the existing behavior on older macOS releases
- correct the README requirement and known-issue guidance from macOS 26.4 to 26.5
- add a deterministic standalone policy check for the version/autokill matrix

## Why

D4Mac's bundled `d4-kick`/watchdog hooks were introduced as recovery mechanisms for the older Rosetta deadlock. CodeWeavers now states that its workaround is no longer required starting with macOS 26.5, while also clarifying that both the Wine changes from CrossOver 26.1 and the Rosetta changes from macOS 26.5 are required:

https://www.codeweavers.com/blog/mjohnson/2026/5/18/finally-diablo-iv-and-overwatch-are-playable-with-crossover-261-macos-265

D4Mac 0.4.1 already bundles Wine 11.0 based on the CrossOver 26.1 sources, but its legacy recovery hooks remain armed on macOS 26.5+. Leaving a wait-semantics workaround enabled after the platform fix is no longer beneficial and is a plausible cause of the abrupt exits reported in #10.

## Reproduction and A/B observation

Test environment:

- MacBook Pro (Apple M3 Max, 36 GB)
- macOS 26.5.2
- D4Mac 0.4.1 (9), Wine 11.0, GPTK 3.0
- current Diablo IV build through Battle.net

Before the change, Diablo IV exited abruptly four times after roughly 3-23 minutes. Battle.net remained open and neither macOS nor Blizzard produced a crash report.

Launching the same installation with `D4_KICK_DISABLE=1` and `D4_WATCHDOG_DISABLE=1` produced a session longer than 30 minutes without an abrupt exit. One world transition stalled for about five minutes, but the process stayed alive, reconnected, and resumed without being closed. The user then exited normally.

A separately built and ad-hoc-signed app containing this patch successfully launched the existing Battle.net bottle and Diablo IV installation; the client initialized the world and its process/log remained active during the smoke test.

This is intentionally a draft: the A/B result is strong evidence for the mitigation, but the recoverable stall means it should not yet be described as a complete root-cause proof.

## Validation

- `swiftc -frontend -parse Sources/D4Mac/*.swift`
- standalone policy matrix: macOS 26.3, 26.4, 26.5 and future releases, with autokill on/off
- `git diff --check`
- release binary built and exercised against the existing 88 GB installation
- app signature verified with `codesign --verify --deep --strict`

The local release build used temporary guards around the two existing `#Preview` blocks because the bare Command Line Tools installation does not provide `PreviewsMacros`. Those unrelated guards were removed before this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Diablo IV stability on macOS by applying compatibility settings based on the installed macOS version.
  * Updated watchdog recovery behavior to support newer macOS releases while preserving user preferences.

* **Documentation**
  * Updated requirements and known-issue guidance to recommend macOS 26.5 Tahoe or later.
  * Revised troubleshooting information for mid-game freezes and Rosetta-related compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->