### PR TITLE
Bundle SDL2 + Sony-pad hidraw override: gamepads reach games as XInput

### DIFF
--- a/Prereqs/fetch-wine-libs.py
+++ b/Prereqs/fetch-wine-libs.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
-"""Stage the x86_64 FreeType/GnuTLS dependency chain for bundling in
+"""Stage the x86_64 FreeType/GnuTLS/SDL2 dependency chain for bundling in
 D4Mac.app's Wine runtime (Contents/SharedSupport/Wine/lib/external/).
 
 Why this exists
 ---------------
 The bundled Wine is x86_64 (runs under Rosetta). At runtime it dlopen()s a
 handful of unix libraries by bare leaf name — `libfreetype.6.dylib` (font
-rendering, used by win32u) and `libgnutls.30.dylib` (TLS, used by secur32/
-bcrypt). Those names are resolved via DYLD_FALLBACK_LIBRARY_PATH, which the
+rendering, used by win32u), `libgnutls.30.dylib` (TLS, used by secur32/
+bcrypt) and `libSDL2-2.0.0.dylib` (game-controller backend, used by
+winebus). Those names are resolved via DYLD_FALLBACK_LIBRARY_PATH, which the
 launcher points at `lib/external` first (see BNetLauncher.swift). If no
 x86_64 build of these libs is found there, dyld falls back to /usr/local/lib
 — i.e. an *Intel* Homebrew install. Apple Silicon users who only have ARM
 Homebrew (/opt/homebrew) get nothing, so Battle.net Setup renders blank text
-(no FreeType) and downloads fail (no GnuTLS).
+(no FreeType), downloads fail (no GnuTLS), and gamepads never reach games
+as XInput devices (no SDL2 → winebus falls back to raw IOHID, which never
+spawns the winexinput XI_00/IG_00 interfaces — GitHub issue #13).
 
 Shipping x86_64 builds of the whole chain inside lib/external fixes this for
 every Apple Silicon user, with no Intel Homebrew required.
@@ -49,7 +52,8 @@ import sys
 import tarfile
 import urllib.request
 
-# Formulae whose x86_64 bottles supply the FreeType + GnuTLS dependency chain.
+# Formulae whose x86_64 bottles supply the FreeType + GnuTLS + SDL2
+# dependency chains.
 FORMULAE = [
     "freetype",
     "gnutls",
@@ -61,12 +65,13 @@ FORMULAE = [
     "p11-kit",
     "libidn2",
     "libunistring",
+    "sdl2",
 ]
 
 # The libraries Wine dlopen()s by bare leaf name (confirmed via `strings` on
-# win32u.so / secur32.so / bcrypt.so). Everything else is pulled in as a
-# transitive dependency by the BFS closure below.
-SEEDS = ["libfreetype.6.dylib", "libgnutls.30.dylib"]
+# win32u.so / secur32.so / bcrypt.so / winebus.so). Everything else is pulled
+# in as a transitive dependency by the BFS closure below.
+SEEDS = ["libfreetype.6.dylib", "libgnutls.30.dylib", "libSDL2-2.0.0.dylib"]
 
 # x86_64 macOS bottle tags, preferred newest-first. We never want arm64_* or
 # *_linux. A formula's newest version usually still has one of these on GHCR.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ cd D4Mac
 Resources/Fonts/fetch.sh   # downloads MS Core Fonts (one-time)
 Prereqs/fetch.sh           # downloads VC++ Redistributable (one-time)
 # build.sh also auto-runs Prereqs/fetch-wine-libs.py to stage the x86_64
-# FreeType/GnuTLS chain into the Wine runtime (one-time, ~8 MB from GHCR).
+# FreeType/GnuTLS/SDL2 chain into the Wine runtime (one-time, ~10 MB from GHCR).
 ./build.sh                 # debug build
 ./build.sh --release       # optimised
 ./build.sh --release --notarize --dmg   # full release pipeline
@@ -149,7 +149,7 @@ manipulation, no admin password.
 | `Resources/`                 | App icon, `Info.plist`, fonts, entitlements                                                          |
 | `Resources/Fonts/fetch.sh`   | One-time fetch of MS Core Fonts For The Web                                                          |
 | `Prereqs/fetch.sh`           | One-time fetch of VC++ Redistributable installers                                                    |
-| `Prereqs/fetch-wine-libs.py` | Stages the x86_64 FreeType/GnuTLS chain into Wine's `lib/external` (GHCR bottles)                    |
+| `Prereqs/fetch-wine-libs.py` | Stages the x86_64 FreeType/GnuTLS/SDL2 chain into Wine's `lib/external` (GHCR bottles)               |
 | `web/`                       | The [d4mac.com](https://d4mac.com) Next.js site (download landing page, BMC tip checkout, dashboard) |
 | `build.sh`                   | Build / notarise / DMG packaging                                                                     |
 | `THIRD_PARTY_LICENSES.md`    | Per-component licence breakdown                                                                      |

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.2</string>
+	<string>0.4.3</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/D4Mac/BottleManager.swift
+++ b/Sources/D4Mac/BottleManager.swift
@@ -185,6 +185,7 @@ final class BottleManager: ObservableObject {
         }
 
         try? await disableCrashDialog()
+        try? await seedControllerRegistry()
         try await deployGPTKBinaries()
         try installCoreFonts()
         try await installPrerequisites()
@@ -313,6 +314,51 @@ final class BottleManager: ObservableObject {
             ]
         )
         _ = try await proc.run()
+    }
+
+    /// Route Sony gamepads through winebus's SDL backend instead of raw
+    /// IOHID. Wine force-prefers "hidraw" (raw HID reports) for DualShock 4
+    /// and DualSense pads, but on macOS the raw path only yields a generic
+    /// HID device — no WINE_COMP_XINPUT compatible id, no winexinput
+    /// XI_00/IG_00 interfaces — so XInput-only games like Diablo IV see no
+    /// controller at all. A per-device `Hidraw=0` under
+    /// Services\WineBus\Devices flips just these pads onto the SDL path
+    /// (libSDL2 is bundled in lib/external), which exposes them as XInput
+    /// gamepads; winebus then drops the raw IOHID duplicate, so inputs are
+    /// never doubled. Xbox pads already default to the SDL path and need no
+    /// override. Diagnosed by @imimips-svg in issue #13.
+    private func seedControllerRegistry() async throws {
+        let marker = bottleRoot.appendingPathComponent(".d4mac-controller-reg-v1")
+        if FileManager.default.fileExists(atPath: marker.path) { return }
+
+        // VID 054c (Sony) PIDs that Wine's is_hidraw_enabled() force-prefers
+        // hidraw for (winebus.sys/unixlib.h): DualShock 4 v1 [CUH-ZCT1x],
+        // v2 [CUH-ZCT2x], the DS4 USB wireless adaptor, DualSense, and
+        // DualSense Edge.
+        let sonyPadPIDs = ["05c4", "09cc", "0ba0", "0ce6", "0df2"]
+        for pid in sonyPadPIDs {
+            let proc = WineProcess(
+                wine: wineBin,
+                prefix: bottleRoot,
+                externalLibDir: libExternal,
+                args: [
+                    "reg", "add",
+                    #"HKLM\System\CurrentControlSet\Services\WineBus\Devices\054c/"# + pid,
+                    "/v", "Hidraw",
+                    "/t", "REG_DWORD",
+                    "/d", "0",
+                    "/f"
+                ]
+            )
+            let status = try await proc.run()
+            guard status == 0 else {
+                // No marker written → retried on next launch.
+                log.warning("controller registry seed failed for 054c/\(pid) (exit \(status))")
+                return
+            }
+        }
+        log.info("seeded Hidraw=0 for \(sonyPadPIDs.count) Sony pad ids (SDL → XInput path)")
+        try? "ok".write(to: marker, atomically: true, encoding: .utf8)
     }
 
     /// Copy/hardlink GPTK PE DLLs into the bottle's system32. Replaces Wine's

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -181,3 +181,21 @@ so the LGPL relinking provision is satisfiable):
 (`ghcr.io/homebrew/core/*`), staged by `Prereqs/fetch-wine-libs.py`. The
 complete corresponding source for each library is available from its
 upstream above and from [github.com/Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core).
+
+## SDL2
+
+**Files in bundle**: `Contents/SharedSupport/Wine/lib/external/libSDL2-2.0.0.dylib`
+
+**Why bundled**: Wine's `winebus.sys` game-controller backend `dlopen()`s
+`libSDL2-2.0.0.dylib` by leaf name; without it, gamepads fall back to the
+raw IOHID path and are never exposed to games as XInput devices, so
+XInput-only titles like Diablo IV detect no controller at all.
+
+**Modifications**: unmodified library code. Only the Mach-O install name is
+rewritten to `@rpath/libSDL2-2.0.0.dylib` (via `install_name_tool`) so dyld
+resolves it from `lib/external`. No compiled code is altered.
+
+**Licence**: zlib. Upstream: [libsdl.org](https://www.libsdl.org).
+
+**Source**: prebuilt x86_64 macOS bottle from Homebrew's GHCR registry
+(`ghcr.io/homebrew/core/sdl2`), staged by `Prereqs/fetch-wine-libs.py`.

--- a/build.sh
+++ b/build.sh
@@ -122,26 +122,31 @@ find "$APP/Contents/SharedSupport/Wine" \
   \( -name "*.bak" -o -name "*.before-*" -o -name "*.orig" \
      -o -name "*.pre-*" -o -name "wineserver.x86_64" \) -delete
 
-# Bundled x86_64 FreeType/GnuTLS chain. Wine dlopen()s these libraries by
-# bare leaf name (libfreetype.6.dylib, libgnutls.30.dylib, …) and resolves
-# them out of lib/external via DYLD_FALLBACK_LIBRARY_PATH (see
-# BNetLauncher.swift). Without them, Apple Silicon users who have only ARM
-# Homebrew — or none at all — get blank text in Battle.net Setup (no FreeType)
-# and TLS failures (no GnuTLS), because dyld's only fallback was an Intel
-# Homebrew under /usr/local/lib. Fetched on demand from Homebrew's GHCR bottle
-# registry (no Homebrew required) — see Prereqs/fetch-wine-libs.py.
+# Bundled x86_64 FreeType/GnuTLS/SDL2 chain. Wine dlopen()s these libraries
+# by bare leaf name (libfreetype.6.dylib, libgnutls.30.dylib,
+# libSDL2-2.0.0.dylib, …) and resolves them out of lib/external via
+# DYLD_FALLBACK_LIBRARY_PATH (see BNetLauncher.swift). Without them, Apple
+# Silicon users who have only ARM Homebrew — or none at all — get blank text
+# in Battle.net Setup (no FreeType), TLS failures (no GnuTLS), and gamepads
+# that never reach games as XInput devices (no SDL2 for winebus — issue #13),
+# because dyld's only fallback was an Intel Homebrew under /usr/local/lib.
+# Fetched on demand from Homebrew's GHCR bottle registry (no Homebrew
+# required) — see Prereqs/fetch-wine-libs.py. The freshness check names every
+# seed so a wine-libs dir cached by an older checkout refetches the new libs.
 WINELIBS_SRC="$SCRIPT_DIR/Prereqs/wine-libs"
 WINELIBS_DST="$APP/Contents/SharedSupport/Wine/lib/external"
-if [ ! -f "$WINELIBS_SRC/libfreetype.6.dylib" ]; then
-  echo "==> fetching x86_64 Wine support libs (one-time, ~8 MB)"
+if [ ! -f "$WINELIBS_SRC/libfreetype.6.dylib" ] \
+   || [ ! -f "$WINELIBS_SRC/libSDL2-2.0.0.dylib" ]; then
+  echo "==> fetching x86_64 Wine support libs (one-time, ~10 MB)"
   /usr/bin/python3 "$SCRIPT_DIR/Prereqs/fetch-wine-libs.py"
 fi
-if [ -f "$WINELIBS_SRC/libfreetype.6.dylib" ]; then
+if [ -f "$WINELIBS_SRC/libfreetype.6.dylib" ] \
+   && [ -f "$WINELIBS_SRC/libSDL2-2.0.0.dylib" ]; then
   mkdir -p "$WINELIBS_DST"
   cp -p "$WINELIBS_SRC"/*.dylib "$WINELIBS_DST/"
   echo "bundled wine libs ($(ls "$WINELIBS_SRC"/*.dylib | wc -l | tr -d ' ') x86_64 dylibs)"
 else
-  echo "warning: $WINELIBS_SRC missing — FreeType/GnuTLS won't be bundled"
+  echo "warning: $WINELIBS_SRC incomplete — FreeType/GnuTLS/SDL2 won't be bundled"
 fi
 
 # Make sure binaries are executable post-copy.


### PR DESCRIPTION
Fixes #13.

## What was broken

Controllers worked in macOS and were visible to Battle.net, but Diablo IV (XInput-only) saw nothing. Two stacked causes, exactly as diagnosed by @imimips-svg in #13:

1. Our `winebus.so` ships with the SDL controller backend compiled in — it `dlopen()`s `libSDL2-2.0.0.dylib` — but the app never bundled that library. The backend silently died and every pad fell back to raw IOHID: a generic HID device with no `WINE_COMP_XINPUT` compatible id and no `winexinput` `XI_00`/`IG_00` interfaces.
2. Even with SDL2 present, Wine force-prefers hidraw for DualShock 4 / DualSense (`is_hidraw_enabled()` in `winebus.sys/main.c`), so the SDL device would be discarded (`ignoring non-hidraw device`).

The `xbox_bus_init disabled: Sequoia` line from the report is upstream CrossOver behavior for wired Xbox 360 pads only — a red herring for this bug, left untouched.

## The fix

- **`Prereqs/fetch-wine-libs.py`**: stage the x86_64 SDL2 Homebrew bottle (zlib licence, 2.32.10) into `lib/external`, same mechanism as the FreeType/GnuTLS chain from #4. `winebus` finds it via the `DYLD_FALLBACK_LIBRARY_PATH` the launcher already sets — zero new env plumbing. `build.sh`'s freshness check now names every seed dylib so a cached `wine-libs` dir from an older checkout refetches.
- **`BottleManager.seedControllerRegistry()`**: seed `Hidraw=0` under `HKLM\System\CurrentControlSet\Services\WineBus\Devices\054c/<pid>` for the five Sony PIDs Wine hardcodes as hidraw-preferred (DS4 v1 `05c4`, v2 `09cc`, DS4 wireless adaptor `0ba0`, DualSense `0ce6`, DualSense Edge `0df2`). Idempotent via bottle marker; runs on existing bottles at next launch. The per-device override is checked first in `is_hidraw_enabled()`, so it wins; `winebus` then keeps the SDL device and drops the raw IOHID duplicate (`main.c` requires `is_hidraw` to match), so inputs are never doubled.
- Xbox pads need no override — they already default to the SDL path, so bundling the dylib alone activates them too.

## Verification (scratch prefix, no controller hardware needed)

- `fetch-wine-libs.py` stages `libSDL2-2.0.0.dylib` `[x86_64]`, closure clean (12 dylibs, no new transitive deps).
- The dylib loads under Rosetta (`ctypes.CDLL` via `arch -x86_64`, reports SDL 2.32.10).
- The exact `reg add` command (forward-slash key name) exits 0 and lands in `system.reg` byte-identical to the reporter's confirmed-working representation.
- `WINEDEBUG=+hid wineboot` shows both log lines whose absence defined the bug:
  - `trace:hid:bus_main_thread L"SDL" main loop started`
  - `trace:hid:load_device_options - 054c/05c4: disabling hidraw`
- `swift build` clean.

End-to-end with a physical DS4 is pending — a preview build is going to the reporter on #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)